### PR TITLE
Proposal:  Action button on rectangle snackBars

### DIFF
--- a/example/lib/action_button.dart
+++ b/example/lib/action_button.dart
@@ -1,0 +1,65 @@
+// Widget que vamos a utilizar tanto para el boton de filtrar la tabla como el de ordenar la tabla
+import 'package:flutter/material.dart';
+
+class AcctionButon extends StatelessWidget {
+  final Color color;
+  final Color backgroundColor;
+  final Color overlayColor;
+  final String text;
+  final IconData icon;
+  final double borderWidth;
+  final Size size;
+  final Function() onClick;
+
+  const AcctionButon({
+    super.key,
+    this.color = Colors.white,
+    required this.text,
+    required this.borderWidth,
+    required this.icon,
+    this.backgroundColor = Colors.white,
+    required this.size,
+    required this.onClick,
+    required this.overlayColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      onPressed: onClick,
+      style: ButtonStyle(
+        backgroundColor: WidgetStatePropertyAll(backgroundColor),
+        side: borderWidth > 0.0
+            ? WidgetStateProperty.all(
+                BorderSide(color: color, width: borderWidth))
+            : null,
+        shape: WidgetStateProperty.all(
+          RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(4.0),
+          ),
+        ),
+        overlayColor: WidgetStateProperty.all(overlayColor),
+        fixedSize: WidgetStateProperty.all(size),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            icon,
+            color: color,
+          ),
+          const SizedBox(
+            width: 5,
+          ),
+          // Necesito que coja todo el resto del espacio para que se centre correctamente
+          Expanded(
+            child: Text(
+              text,
+              style: TextStyle(color: color, fontSize: 15),
+              textAlign: TextAlign.center,
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:animated_snack_bar/animated_snack_bar.dart';
+import 'package:example/action_button.dart';
 import 'package:flutter/material.dart';
 
 void main() {
@@ -207,6 +208,27 @@ class _MyHomePageState extends State<MyHomePage> {
                   );
                 }),
                 child: const Text("Success"),
+              ),
+              const SizedBox(height: 10),
+              ElevatedButton(
+                onPressed: (() {
+                  AnimatedSnackBar.rectangle('Info', 'Document downloaded',
+                          type: AnimatedSnackBarType.info,
+                          brightness: Brightness.light,
+                          actionButton: AcctionButon(
+                              text: 'Open',
+                              borderWidth: 2.0,
+                              icon: Icons.open_in_new,
+                              size: const Size(100, 10),
+                              onClick: () => print('Performing an action'),
+                              color: Colors.green[700]!,
+                              backgroundColor: Colors.white,
+                              overlayColor: Colors.grey[350]!))
+                      .show(
+                    context,
+                  );
+                }),
+                child: const Text("ActionButton"),
               ),
               const SizedBox(height: 10),
               ElevatedButton(

--- a/lib/src/animated_snack_bar.dart
+++ b/lib/src/animated_snack_bar.dart
@@ -116,27 +116,28 @@ class AnimatedSnackBar {
 
   /// Creates a rectangle style snack bar.
   /// Remember to call [show] method to show the snack bar.
-  factory AnimatedSnackBar.rectangle(
-    String titleText,
-    String messageText, {
-    required AnimatedSnackBarType type,
-    DesktopSnackBarPosition desktopSnackBarPosition =
-        DesktopSnackBarPosition.bottomLeft,
-    MobileSnackBarPosition mobileSnackBarPosition = MobileSnackBarPosition.top,
-    Duration duration = const Duration(seconds: 8),
-    Brightness? brightness,
-    MultipleSnackBarStrategy snackBarStrategy = const ColumnSnackBarStrategy(),
-    MobilePositionSettings mobilePositionSettings =
-        const MobilePositionSettings(),
-    Duration animationDuration = const Duration(milliseconds: 400),
-    Curve animationCurve = Curves.easeInOut,
-  }) {
+  factory AnimatedSnackBar.rectangle(String titleText, String messageText,
+      {required AnimatedSnackBarType type,
+      DesktopSnackBarPosition desktopSnackBarPosition =
+          DesktopSnackBarPosition.bottomLeft,
+      MobileSnackBarPosition mobileSnackBarPosition =
+          MobileSnackBarPosition.top,
+      Duration duration = const Duration(seconds: 8),
+      Brightness? brightness,
+      MultipleSnackBarStrategy snackBarStrategy =
+          const ColumnSnackBarStrategy(),
+      MobilePositionSettings mobilePositionSettings =
+          const MobilePositionSettings(),
+      Duration animationDuration = const Duration(milliseconds: 400),
+      Curve animationCurve = Curves.easeInOut,
+      Widget? actionButton}) {
     final WidgetBuilder builder = ((context) {
       return RectangleAnimatedSnackBar(
         titleText: titleText,
         messageText: messageText,
         type: type,
         brightness: brightness ?? Theme.of(context).brightness,
+        actionButton: actionButton,
       );
     });
 

--- a/lib/src/widgets/rectangle_animated_snack_bar.dart
+++ b/lib/src/widgets/rectangle_animated_snack_bar.dart
@@ -21,6 +21,7 @@ class RectangleAnimatedSnackBar extends StatelessWidget {
     this.iconData,
     this.foregroundColor,
     this.backgroundColor,
+    this.actionButton,
   }) : super(key: key);
 
   final String titleText;
@@ -33,6 +34,7 @@ class RectangleAnimatedSnackBar extends StatelessWidget {
   final IconData? iconData;
   final Color? foregroundColor;
   final Color? backgroundColor;
+  final Widget? actionButton;
 
   Color? get primary {
     if (brightness == Brightness.dark) {
@@ -125,6 +127,11 @@ class RectangleAnimatedSnackBar extends StatelessWidget {
                       Theme.of(context).textTheme.bodyLarge?.copyWith(
                           color: Colors.white, fontWeight: FontWeight.w300),
                 ),
+                if (actionButton != null)
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [actionButton!],
+                  )
               ],
             ),
           )


### PR DESCRIPTION
Here is my PR to introduce my proposal to let the .rectangle() snackbars have a new optional Widget called 'actionButton'.
The idea is to bring the user perform some kind of quick action after reciving information, like, for example, open a file that has been downloaded.

Examples:
![Captura de pantalla 2024-07-07 a las 22 10 46](https://github.com/JulyWitch/animated_snack_bar/assets/56364044/26515725-c919-4384-b996-d0c42caa3018)
![Captura de pantalla 2024-07-07 a las 22 10 32](https://github.com/JulyWitch/animated_snack_bar/assets/56364044/1e318cd9-1d20-4ec8-b757-81b94ccd60b3)
